### PR TITLE
Ad statistics

### DIFF
--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/GetAdAccountStatisticsTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/GetAdAccountStatisticsTest.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using facebook_csharp_ads_sdk.Domain.Contracts.Repository;
+using facebook_csharp_ads_sdk.Infrastructure.Repository;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
+{
+    [TestClass]
+    public class GetAdAccountStatisticsTest : TestBase
+    {
+        readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
+        readonly IAdStatisticsRepository adStatisticsRepository = new AdStatisticsRepository(new FacebookSessionRepository());
+
+        private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository, adStatisticsRepository);
+        }
+
+        [TestMethod]
+        public void CanGetStatistics()
+        {
+            var startDate = DateTime.UtcNow.AddDays(-7);
+            var EndDate = DateTime.UtcNow;
+            var stats = model.GetStatistics(startDate, EndDate);
+            Assert.IsTrue(stats.Result.IsValid);
+        }
+
+        [TestMethod]
+        public void CantGetStatisticsWithInvalidDateTime()
+        {
+            var startDate = DateTime.Now.AddDays(-7);
+            var EndDate = DateTime.Now;
+            
+            try
+            {
+                var stats = model.GetStatistics(startDate, EndDate);
+                Assert.Fail("Expected ArgumentException to be thrown.");
+            }
+            catch (ArgumentException ae)
+            {
+                Assert.IsNotNull(ae);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail(string.Format("Unexpected exception of type {0} caught: {1}", e.GetType(), e.Message));
+            }
+        }
+    }
+}

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/ParseSingleResultTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/ParseSingleResultTest.cs
@@ -7,7 +7,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     [TestClass]
     public class ParseSingleResultTest : TestBase
     {
-        readonly IAccountRepository accountRepository = new AdAccountRespository(new FacebookSessionRepository());
+        readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/ParseSingleResultTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/ParseSingleResultTest.cs
@@ -8,12 +8,14 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     public class ParseSingleResultTest : TestBase
     {
         readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
+        readonly IAdStatisticsRepository adStatisticsRepository = new AdStatisticsRepository(new FacebookSessionRepository());
+
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]
         public void Initialize()
         {
-            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository);
+            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository, adStatisticsRepository);
         }
 
         [TestMethod]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountAgencyDeclarationTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountAgencyDeclarationTest.cs
@@ -7,7 +7,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     [TestClass]
     public class SetAdAccountAgencyDeclarationTest : TestBase
     {
-        readonly IAccountRepository accountRepository = new AdAccountRespository(new FacebookSessionRepository());
+        readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountAgencyDeclarationTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountAgencyDeclarationTest.cs
@@ -8,12 +8,14 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     public class SetAdAccountAgencyDeclarationTest : TestBase
     {
         readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
+        readonly IAdStatisticsRepository adStatisticsRepository = new AdStatisticsRepository(new FacebookSessionRepository());
+
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]
         public void Initialize()
         {
-            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository);
+            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository, adStatisticsRepository);
         }
 
         [TestMethod]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountBaseDataTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountBaseDataTest.cs
@@ -8,12 +8,13 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     public class SetAdAccountBaseDataTest : TestBase
     {
         readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
+        readonly IAdStatisticsRepository adStatisticsRepository = new AdStatisticsRepository(new FacebookSessionRepository());
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]
         public void Initialize()
         {
-            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository);
+            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository, adStatisticsRepository);
         }
 
         [TestMethod]
@@ -480,7 +481,9 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
 
         private static void RenewModel(out facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model)
         {
-            model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(new AdAccountRepository(new FacebookSessionRepository()));
+            model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(
+                new AdAccountRepository(new FacebookSessionRepository()), 
+                new AdStatisticsRepository(new FacebookSessionRepository()));
             Assert.IsFalse(model.IsValid);
         }
     }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountBaseDataTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountBaseDataTest.cs
@@ -7,7 +7,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     [TestClass]
     public class SetAdAccountBaseDataTest : TestBase
     {
-        readonly IAccountRepository accountRepository = new AdAccountRespository(new FacebookSessionRepository());
+        readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]
@@ -480,7 +480,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
 
         private static void RenewModel(out facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model)
         {
-            model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(new AdAccountRespository(new FacebookSessionRepository()));
+            model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(new AdAccountRepository(new FacebookSessionRepository()));
             Assert.IsFalse(model.IsValid);
         }
     }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountBusinessInformationsTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountBusinessInformationsTest.cs
@@ -7,7 +7,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     [TestClass]
     public class SetAdAccountBusinessInformationsTest : TestBase
     {
-        readonly IAccountRepository accountRepository = new AdAccountRespository(new FacebookSessionRepository());
+        readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountBusinessInformationsTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountBusinessInformationsTest.cs
@@ -8,12 +8,14 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     public class SetAdAccountBusinessInformationsTest : TestBase
     {
         readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
+        readonly IAdStatisticsRepository adStatisticsRepository = new AdStatisticsRepository(new FacebookSessionRepository());
+
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]
         public void Initialize()
         {
-            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository);
+            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository, adStatisticsRepository);
         }
 
         [TestMethod]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountFinancialInformationsTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountFinancialInformationsTest.cs
@@ -7,7 +7,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     [TestClass]
     public class SetAdAccountFinancialInformationsTest : TestBase
     {
-        readonly IAccountRepository accountRepository = new AdAccountRespository(new FacebookSessionRepository());
+        readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountFinancialInformationsTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountFinancialInformationsTest.cs
@@ -8,12 +8,14 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     public class SetAdAccountFinancialInformationsTest : TestBase
     {
         readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
+        readonly IAdStatisticsRepository adStatisticsRepository = new AdStatisticsRepository(new FacebookSessionRepository());
+
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]
         public void Initialize()
         {
-            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository);
+            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository, adStatisticsRepository);
         }
 
         [TestMethod]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountGroupTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountGroupTest.cs
@@ -8,12 +8,13 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     public class SetAdAccountGroupTest : TestBase
     {
         readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
+        readonly IAdStatisticsRepository adStatisticsRepository = new AdStatisticsRepository(new FacebookSessionRepository());
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]
         public void Initialize()
         {
-            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository);
+            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository, adStatisticsRepository);
         }
 
         [TestMethod]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountGroupTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountGroupTest.cs
@@ -7,7 +7,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     [TestClass]
     public class SetAdAccountGroupTest : TestBase
     {
-        readonly IAccountRepository accountRepository = new AdAccountRespository(new FacebookSessionRepository());
+        readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountTimezoneInformationsTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountTimezoneInformationsTest.cs
@@ -8,12 +8,14 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     public class SetAdAccountTimezoneInformationsTest : TestBase
     {
         readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
+        readonly IAdStatisticsRepository adStatisticsRepository = new AdStatisticsRepository(new FacebookSessionRepository());
+
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]
         public void Initialize()
         {
-            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository);
+            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository, adStatisticsRepository);
         }
 
         [TestMethod]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountTimezoneInformationsTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountTimezoneInformationsTest.cs
@@ -7,7 +7,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     [TestClass]
     public class SetAdAccountTimezoneInformationsTest : TestBase
     {
-        readonly IAccountRepository accountRepository = new AdAccountRespository(new FacebookSessionRepository());
+        readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountUserTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountUserTest.cs
@@ -8,12 +8,14 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     public class SetAdAccountUserTest : TestBase
     {
         readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
+        readonly IAdStatisticsRepository adStatisticsRepository = new AdStatisticsRepository(new FacebookSessionRepository());
+
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]
         public void Initialize()
         {
-            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository);
+            this.model = new facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount(accountRepository, adStatisticsRepository);
         }
 
         [TestMethod]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountUserTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdAccounts/AdAccount/SetAdAccountUserTest.cs
@@ -7,7 +7,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdAccounts.AdAccount
     [TestClass]
     public class SetAdAccountUserTest : TestBase
     {
-        readonly IAccountRepository accountRepository = new AdAccountRespository(new FacebookSessionRepository());
+        readonly IAccountRepository accountRepository = new AdAccountRepository(new FacebookSessionRepository());
         private facebook_csharp_ads_sdk.Domain.Models.AdAccounts.AdAccount model;
 
         [TestInitialize]

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignCreateTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignCreateTest.cs
@@ -26,18 +26,20 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         private AdCampaignObjectiveEnum? campaignObjective = AdCampaignObjectiveEnum.None;
         private AdCampaignStatusEnum campaignStatus = AdCampaignStatusEnum.Active;
         private IList<ExecutionOptionsEnum> executionOptions = null;
+        private Mock<IAdStatisticsRepository> mockAdStatisticsRepository; 
 
         [TestInitialize]
         public void Initialize()
         {
             this.mockCampaignRepository = new Mock<ICampaignRepository>();
+            this.mockAdStatisticsRepository = new Mock<IAdStatisticsRepository>();
         }
 
         [TestMethod]
         public void ShouldReturnErrorIfCampaignIdInvalidToSetCreationData()
         {
             this.accountId = -1;
-            var campaign = new AdCampaign(mockCampaignRepository.Object);
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object);
             campaign.SetCreateData(accountId, campaignName, campaignBuyingType, campaignObjective, campaignStatus, executionOptions);
 
             Assert.AreEqual(0, campaign.Id);
@@ -48,7 +50,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         public void ShouldReturnErrorIfCampaignNameEmptyToSetCreationData()
         {
             this.campaignName = string.Empty;
-            var campaign = new AdCampaign(mockCampaignRepository.Object);
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object);
             campaign.SetCreateData(accountId, campaignName, campaignBuyingType, campaignObjective, campaignStatus, executionOptions);
 
             Assert.AreEqual(0, campaign.Id);
@@ -59,7 +61,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         public void ShouldReturnErrorIfCampaignStatusUndefinedToSetCreationData()
         {
             this.campaignStatus = AdCampaignStatusEnum.Undefined;
-            var campaign = new AdCampaign(mockCampaignRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
                 campaignObjective, campaignStatus, executionOptions);
 
             Assert.AreEqual(0, campaign.Id);
@@ -70,7 +72,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         public void ShouldReturnErrorIfCampaignStatusArchivedToSetCreationData()
         {
             this.campaignStatus = AdCampaignStatusEnum.Archived;
-            var campaign = new AdCampaign(mockCampaignRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
                 campaignObjective, campaignStatus, executionOptions);
 
             Assert.AreEqual(0, campaign.Id);
@@ -81,7 +83,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         public void ShouldReturnErrorIfCampaignStatusDeleteToSetCreationData()
         {
             this.campaignStatus = AdCampaignStatusEnum.Delete;
-            var campaign = new AdCampaign(mockCampaignRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
                 campaignObjective, campaignStatus, executionOptions);
 
             Assert.AreEqual(0, campaign.Id);
@@ -92,7 +94,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         public void MustAssignAdCampaignBuyingTypeNullIfParemeterUndefined()
         {
             this.campaignBuyingType = AdCampaignBuyingTypeEnum.Undefined;
-            var campaign = new AdCampaign(mockCampaignRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
                 campaignObjective, campaignStatus, executionOptions);
 
             Assert.IsNull(campaign.BuyingType);
@@ -104,7 +106,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         {
             this.campaignObjective = AdCampaignObjectiveEnum.Undefined;
 
-            var campaign = new AdCampaign(mockCampaignRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
                 campaignObjective, campaignStatus, executionOptions);
 
             Assert.IsNull(campaign.Objective);
@@ -115,7 +117,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         public void ShouldNotCreateAdCampaignIfModelNotValidToCreate()
         {
             campaignName = string.Empty;
-            var campaign = new AdCampaign(mockCampaignRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
                 campaignObjective, campaignStatus, executionOptions);
 
             AdCampaign campaignCreated = campaign.Create();
@@ -135,7 +137,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
                     executionOptions.Select(
                         u => "\"" + u.ToEnum<ExecutionOptionsEnum>().GetExecutionOptionsFacebookName() + "\"")));
 
-            var campaign = new AdCampaign(mockCampaignRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object).SetCreateData(accountId, campaignName, campaignBuyingType,
                    campaignObjective, campaignStatus, executionOptions);
 
             Dictionary<string, string> dictionaryWithParams = campaign.GetSingleCreateParams();

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignDeleteTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignDeleteTest.cs
@@ -12,17 +12,19 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
     public class AdCampaignDeleteTest
     {
         private Mock<ICampaignRepository> mockCampaignRepository;
+        private Mock<IAdStatisticsRepository> mockAdStatisticsRepository; 
 
         [TestInitialize]
         public void Initialize()
         {
             mockCampaignRepository = new Mock<ICampaignRepository>();
+            mockAdStatisticsRepository = new Mock<IAdStatisticsRepository>();
         }
 
         [TestMethod]
         public void ShouldReturnFalseToDeleteWithParameterIfIdInvalid()
         {
-            var campaign = new AdCampaign(mockCampaignRepository.Object);
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object);
 
             bool successDelete = campaign.Delete(0);
             mockCampaignRepository.Verify(m => m.Delete(It.IsAny<long>()), Times.Never);
@@ -32,7 +34,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         [TestMethod]
         public void ShouldReturnFalseToDeleteWithoutParameterIfIdInvalid()
         {
-            var campaign = new AdCampaign(mockCampaignRepository.Object);
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object);
             campaign.ParseReadSingleResponse("{'id': '0'}");
 
             bool successDelete = campaign.Delete();

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignDeleteTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignDeleteTest.cs
@@ -33,7 +33,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         public void ShouldReturnFalseToDeleteWithoutParameterIfIdInvalid()
         {
             var campaign = new AdCampaign(mockCampaignRepository.Object);
-            campaign.ParseReadSingleesponse("{'id': '0'}");
+            campaign.ParseReadSingleResponse("{'id': '0'}");
 
             bool successDelete = campaign.Delete();
             mockCampaignRepository.Verify(m => m.Delete(It.IsAny<long>()), Times.Never);

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignReadParseTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignReadParseTest.cs
@@ -38,7 +38,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         public void MustSetErrorIfFacebookReturnError()
         {
             var campaign = new AdCampaign(campaignRepository);
-            campaign.ParseReadSingleesponse(FacebookError);
+            campaign.ParseReadSingleResponse(FacebookError);
             Assert.AreEqual(0, campaign.Id);
             Assert.IsFalse(campaign.IsValid);
             Assert.IsNotNull(campaign.ApiErrorResponseData);
@@ -50,7 +50,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         {
             this.SetFacebookResponseOkWithAllFields();
             var campaign = new AdCampaign(campaignRepository);
-            campaign.ParseReadSingleesponse(facebookResponseGetAdCampaign);
+            campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
 
             Assert.IsTrue(campaign.IsValid);
             Assert.IsNull(campaign.ApiErrorResponseData);
@@ -77,7 +77,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
             this.SetFacebookResponseOkWithAllFields();
 
             var campaign = new AdCampaign(campaignRepository);
-            campaign.ParseReadSingleesponse(facebookResponseGetAdCampaign);
+            campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
             Assert.IsFalse(campaign.IsValid);
         }
 
@@ -86,7 +86,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         {
             this.facebookResponseGetAdCampaign = null;
             var campaign = new AdCampaign(campaignRepository);
-            campaign.ParseReadSingleesponse(facebookResponseGetAdCampaign);
+            campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
             Assert.IsFalse(campaign.IsValid);
         }
 
@@ -95,7 +95,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         {
             this.facebookResponseGetAdCampaign = string.Empty;
             var campaign = new AdCampaign(campaignRepository);
-            campaign.ParseReadSingleesponse(facebookResponseGetAdCampaign);
+            campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
             Assert.IsFalse(campaign.IsValid);
         }
 
@@ -107,7 +107,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
                                                  "'paging': {'cursors': {'before': 'NjAxOTA5MTc1NDE4OA==', 'after': 'NjAxNjE3MDE4MDE4OA=='}}}}";
 
             var campaign = new AdCampaign(campaignRepository);
-            campaign.ParseReadSingleesponse(facebookResponseGetAdCampaign);
+            campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
             Assert.IsTrue(campaign.IsValid);
             Assert.AreEqual(this.campaignIdExpected, campaign.Id);
             Assert.IsNull(campaign.AdGroups);
@@ -122,7 +122,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
                                                  "'paging': {'cursors': {'before': 'NjAxOTA5MTc1NDE4OA==', 'after': 'NjAxNjE3MDE4MDE4OA=='}}}}";
 
             var campaign = new AdCampaign(campaignRepository);
-            campaign.ParseReadSingleesponse(facebookResponseGetAdCampaign);
+            campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
             Assert.IsTrue(campaign.IsValid);
             Assert.AreEqual(this.campaignIdExpected, campaign.Id);
             Assert.IsNull(campaign.AdGroups);

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignReadParseTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignReadParseTest.cs
@@ -27,17 +27,20 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         private const AdCampaignStatusEnum CampaignStatusExpected = AdCampaignStatusEnum.Paused;
         string facebookResponseGetAdCampaign = string.Empty;
 
+        private AdStatisticsRepository adStatisticsRepository; 
+
         [TestInitialize]
         public void Initialize()
         {
             IFacebookSession facebookSession = new FacebookSessionRepository();
             campaignRepository = new CampaignRepository(facebookSession);
+            adStatisticsRepository = new AdStatisticsRepository(facebookSession);
         }
 
         [TestMethod]
         public void MustSetErrorIfFacebookReturnError()
         {
-            var campaign = new AdCampaign(campaignRepository);
+            var campaign = new AdCampaign(campaignRepository, adStatisticsRepository);
             campaign.ParseReadSingleResponse(FacebookError);
             Assert.AreEqual(0, campaign.Id);
             Assert.IsFalse(campaign.IsValid);
@@ -49,7 +52,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         public void MustMakeTheCorrectParseIfFacebookDoesNotReturnError()
         {
             this.SetFacebookResponseOkWithAllFields();
-            var campaign = new AdCampaign(campaignRepository);
+            var campaign = new AdCampaign(campaignRepository, adStatisticsRepository);
             campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
 
             Assert.IsTrue(campaign.IsValid);
@@ -76,7 +79,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
             this.campaignIdExpected = 0;
             this.SetFacebookResponseOkWithAllFields();
 
-            var campaign = new AdCampaign(campaignRepository);
+            var campaign = new AdCampaign(campaignRepository, adStatisticsRepository);
             campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
             Assert.IsFalse(campaign.IsValid);
         }
@@ -85,7 +88,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         public void MustSetInvalidDataIfFacebookResponseIsNull()
         {
             this.facebookResponseGetAdCampaign = null;
-            var campaign = new AdCampaign(campaignRepository);
+            var campaign = new AdCampaign(campaignRepository, adStatisticsRepository);
             campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
             Assert.IsFalse(campaign.IsValid);
         }
@@ -94,7 +97,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         public void MustSetInvalidDataIfFacebookResponseIsEmpty()
         {
             this.facebookResponseGetAdCampaign = string.Empty;
-            var campaign = new AdCampaign(campaignRepository);
+            var campaign = new AdCampaign(campaignRepository, adStatisticsRepository);
             campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
             Assert.IsFalse(campaign.IsValid);
         }
@@ -106,7 +109,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
                                                  "'adgroups': {" +
                                                  "'paging': {'cursors': {'before': 'NjAxOTA5MTc1NDE4OA==', 'after': 'NjAxNjE3MDE4MDE4OA=='}}}}";
 
-            var campaign = new AdCampaign(campaignRepository);
+            var campaign = new AdCampaign(campaignRepository, adStatisticsRepository);
             campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
             Assert.IsTrue(campaign.IsValid);
             Assert.AreEqual(this.campaignIdExpected, campaign.Id);
@@ -121,7 +124,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
                                                  "{'id': '" + AdGroupId1Expected + "'}," +
                                                  "'paging': {'cursors': {'before': 'NjAxOTA5MTc1NDE4OA==', 'after': 'NjAxNjE3MDE4MDE4OA=='}}}}";
 
-            var campaign = new AdCampaign(campaignRepository);
+            var campaign = new AdCampaign(campaignRepository, adStatisticsRepository);
             campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
             Assert.IsTrue(campaign.IsValid);
             Assert.AreEqual(this.campaignIdExpected, campaign.Id);

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignUpdateTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignUpdateTest.cs
@@ -84,7 +84,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         {
             string facebookResponseGetAdCampaign = "{'id': '546546546'}";
             var campaign = new AdCampaign(mockCampaignRepository.Object);
-            campaign.ParseReadSingleesponse(facebookResponseGetAdCampaign);
+            campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
 
             mockCampaignRepository.Setup(m => m.Update(It.IsAny<AdCampaign>())).Throws<Exception>();
             campaign.SetUpdateData(accountId, campaignName, campaignObjective, campaignStatus, executionOptions);

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignUpdateTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/AdCampaignUpdateTest.cs
@@ -22,18 +22,20 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         private AdCampaignObjectiveEnum? campaignObjective = AdCampaignObjectiveEnum.None;
         private AdCampaignStatusEnum? campaignStatus = AdCampaignStatusEnum.Active;
         private IList<ExecutionOptionsEnum> executionOptions = null;
+        private Mock<IAdStatisticsRepository> mockAdStatisticsRepository; 
 
         [TestInitialize]
         public void Initialize()
         {
             this.mockCampaignRepository = new Mock<ICampaignRepository>();
+            this.mockAdStatisticsRepository = new Mock<IAdStatisticsRepository>();
         }
 
         [TestMethod]
         public void ShouldReturnErrorIfCampaignIdInvalidToSetUpdateData()
         {
             this.accountId = -1;
-            var campaign = new AdCampaign(mockCampaignRepository.Object);
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object);
             campaign.SetUpdateData(accountId, campaignName, campaignObjective, campaignStatus, executionOptions);
 
             Assert.IsNotNull(campaign);
@@ -48,7 +50,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
             campaignStatus = null;
             executionOptions = null;
 
-            AdCampaign campaign = new AdCampaign(mockCampaignRepository.Object).SetUpdateData(accountId, campaignName,
+            AdCampaign campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object).SetUpdateData(accountId, campaignName,
                 campaignObjective, campaignStatus, executionOptions);
 
             Assert.IsNotNull(campaign);
@@ -60,7 +62,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         {
             campaignObjective = AdCampaignObjectiveEnum.Undefined;
 
-            AdCampaign campaign = new AdCampaign(mockCampaignRepository.Object).SetUpdateData(accountId, campaignName,
+            AdCampaign campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object).SetUpdateData(accountId, campaignName,
                 campaignObjective, campaignStatus, executionOptions);
 
             Assert.IsNotNull(campaign);
@@ -72,7 +74,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         {
             campaignStatus = AdCampaignStatusEnum.Undefined;
 
-            AdCampaign campaign = new AdCampaign(mockCampaignRepository.Object).SetUpdateData(accountId, campaignName,
+            AdCampaign campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object).SetUpdateData(accountId, campaignName,
                 campaignObjective, campaignStatus, executionOptions);
 
             Assert.IsNotNull(campaign);
@@ -83,7 +85,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         public void ShouldReturnErrorIfAnUnexpectedExceptionOccurWhenCallingRepository()
         {
             string facebookResponseGetAdCampaign = "{'id': '546546546'}";
-            var campaign = new AdCampaign(mockCampaignRepository.Object);
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object);
             campaign.ParseReadSingleResponse(facebookResponseGetAdCampaign);
 
             mockCampaignRepository.Setup(m => m.Update(It.IsAny<AdCampaign>())).Throws<Exception>();
@@ -98,7 +100,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         [TestMethod]
         public void ShouldReturnErrorIfUpdateModelIsNotReady()
         {
-            AdCampaign campaign = new AdCampaign(mockCampaignRepository.Object).SetUpdateData(0, campaignName,
+            AdCampaign campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object).SetUpdateData(0, campaignName,
                 campaignObjective, campaignStatus, executionOptions);
 
             campaign = campaign.Update();
@@ -111,7 +113,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
         [TestMethod]
         public void ShouldReturnErrorIfAdCampaignIdIsInvalid()
         {
-            AdCampaign campaign = new AdCampaign(mockCampaignRepository.Object).SetUpdateData(accountId, campaignName,
+            AdCampaign campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object).SetUpdateData(accountId, campaignName,
                 campaignObjective, campaignStatus, executionOptions);
 
             campaign = campaign.Update();

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/GetAdCampaignStatisticsTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Domain/Models/AdCampaigns/GetAdCampaignStatisticsTest.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DevUtils.Enum;
+using facebook_csharp_ads_sdk.Domain.Contracts.Repository;
+using facebook_csharp_ads_sdk.Infrastructure.Repository;
+using facebook_csharp_ads_sdk.Domain.Enums.AdCampaigns;
+using facebook_csharp_ads_sdk.Domain.Enums.Global;
+using facebook_csharp_ads_sdk.Domain.Extensions.Enums.AdCampaigns;
+using facebook_csharp_ads_sdk.Domain.Extensions.Enums.Global;
+using facebook_csharp_ads_sdk.Domain.Models.AdCampaigns;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace facebook_csharp_ads_sdk_unit_test.Domain.Models.AdCampaigns
+{
+    [TestClass]
+    public class GetAdCampaignStatisticsTest : TestBase
+    {
+        private Mock<ICampaignRepository> mockCampaignRepository;
+        private Mock<IAdStatisticsRepository> mockAdStatisticsRepository; 
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            this.mockCampaignRepository = new Mock<ICampaignRepository>();
+            this.mockAdStatisticsRepository = new Mock<IAdStatisticsRepository>();
+        }
+
+        [TestMethod]
+        public void CanGetStatistics()
+        {
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object);
+            var startDate = DateTime.UtcNow.AddDays(-7);
+            var EndDate = DateTime.UtcNow;
+            var stats = campaign.GetStatistics(startDate, EndDate);
+            Assert.IsTrue(stats.Result.IsValid);
+        }
+
+        [TestMethod]
+        public void CantGetStatisticsWithInvalidDateTime()
+        {
+            var campaign = new AdCampaign(mockCampaignRepository.Object, mockAdStatisticsRepository.Object);
+            var startDate = DateTime.Now.AddDays(-7);
+            var EndDate = DateTime.Now;
+            
+            try
+            {
+                var stats = campaign.GetStatistics(startDate, EndDate);
+                Assert.Fail("Expected ArgumentException to be thrown.");
+            }
+            catch (ArgumentException ae)
+            {
+                Assert.IsNotNull(ae);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail(string.Format("Unexpected exception of type {0} caught: {1}", e.GetType(), e.Message));
+            }
+        }
+    }
+}

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Infrastructure/Repository/AdAccountRespositoryTest/ReadTest.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/Infrastructure/Repository/AdAccountRespositoryTest/ReadTest.cs
@@ -12,7 +12,7 @@ namespace facebook_csharp_ads_sdk_unit_test.Infrastructure.Repository.AdAccountR
         [ExpectedException(typeof(ArgumentNullException))]
         public void CantCreateARepositoryInstanceWhenSendInvalidFacebookSessionOnConstructor()
         {
-            RepositoryAdAccount = new AdAccountRespository(null);
+            RepositoryAdAccount = new AdAccountRepository(null);
         }
     }
 }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/TestBase.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/TestBase.cs
@@ -450,7 +450,7 @@ namespace facebook_csharp_ads_sdk_unit_test
             RepositoryFacebookSession.SetDefaultApplication(ValidAppId, ValidAppSecret);
             RepositoryFacebookSession.SetAppAccessToken(ValidAccessToken);
 
-            RepositoryAdAccount = new AdAccountRespository(RepositoryFacebookSession);
+            RepositoryAdAccount = new AdAccountRepository(RepositoryFacebookSession);
         }
     }
 }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/facebook-csharp-ads-sdk-unit-test.csproj
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk-unit-test/facebook-csharp-ads-sdk-unit-test.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Domain\Extensions\Enums\AdCampaigns\AdCampaignStatusEnumExtensionTest.cs" />
     <Compile Include="Domain\Extensions\Enums\Configurations\FacebookAdsApiVersionsExtensions\GetFacebookNameTest.cs" />
     <Compile Include="Domain\Extensions\Enums\Attribute\GetCustomEnumAttributeValueExtension\GetCustomEnumAttributeValueExtensionTest.cs" />
+    <Compile Include="Domain\Models\AdAccounts\AdAccount\GetAdAccountStatisticsTest.cs" />
     <Compile Include="Domain\Models\AdAccounts\AdAccount\ParseSingleResultTest.cs" />
     <Compile Include="Domain\Models\AdAccounts\AdAccount\SetAdAccountBusinessInformationsTest.cs" />
     <Compile Include="Domain\Models\AdAccounts\AdAccount\SetAdAccountUserTest.cs" />
@@ -112,6 +113,7 @@
     <Compile Include="Domain\Models\AdCampaigns\AdCampaignDeleteTest.cs" />
     <Compile Include="Domain\Models\AdCampaigns\AdCampaignReadParseTest.cs" />
     <Compile Include="Domain\Models\AdCampaigns\AdCampaignUpdateTest.cs" />
+    <Compile Include="Domain\Models\AdCampaigns\GetAdCampaignStatisticsTest.cs" />
     <Compile Include="Infrastructure\Repository\AdAccountRespositoryTest\ReadTest.cs" />
     <Compile Include="Infrastructure\Repository\FacebookSessionRepositoryTest\GetUserAccessTokenTest.cs" />
     <Compile Include="Infrastructure\Repository\FacebookSessionRepositoryTest\GetAppAccessTokenTest.cs" />

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Contracts/AdStatistics/IAdStatisticsQueryable.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Contracts/AdStatistics/IAdStatisticsQueryable.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using facebook_csharp_ads_sdk.Domain.Models;
+using facebook_csharp_ads_sdk.Domain.Contracts.Repository;
 
 namespace facebook_csharp_ads_sdk.Domain.Contracts.AdStatistics
 {
@@ -12,6 +14,8 @@ namespace facebook_csharp_ads_sdk.Domain.Contracts.AdStatistics
     /// </summary>
     public interface IAdStatisticsQueryable
     {
-        IList<AdStatistics> stats(DateTime startDateUtc, DateTime endDateUtc);
+        //IAdStatisticsRepository _adStatisticsRepository {get;}
+
+        //BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics> stats(DateTime startDateUtc, DateTime endDateUtc);
     }
 }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Contracts/AdStatistics/IAdStatisticsQueryable.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Contracts/AdStatistics/IAdStatisticsQueryable.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace facebook_csharp_ads_sdk.Domain.Contracts.AdStatistics
+{
+    /// <summary>
+    /// Interface of AdStatistics. Statistics can be retrieved at the ad account, ad set, and ad level
+    /// https://developers.facebook.com/docs/reference/ads-api/adstatistics/v2.2
+    /// </summary>
+    public interface IAdStatisticsQueryable
+    {
+        IList<AdStatistics> stats(DateTime startDateUtc, DateTime endDateUtc);
+    }
+}

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Contracts/AdStatistics/IAdStatisticsQueryable.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Contracts/AdStatistics/IAdStatisticsQueryable.cs
@@ -14,8 +14,8 @@ namespace facebook_csharp_ads_sdk.Domain.Contracts.AdStatistics
     /// </summary>
     public interface IAdStatisticsQueryable
     {
-        //IAdStatisticsRepository _adStatisticsRepository {get;}
+        IAdStatisticsRepository _adStatisticsRepository { get; }
 
-        //BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics> stats(DateTime startDateUtc, DateTime endDateUtc);
+        Task<BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>> GetStatistics(DateTime? startDateUtc, DateTime? endDateUtc);
     }
 }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Contracts/Repository/IAdStatisticsRepository.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Contracts/Repository/IAdStatisticsRepository.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using facebook_csharp_ads_sdk.Domain.Models;
+using facebook_csharp_ads_sdk.Domain.Models.AdStatistics;
+
+namespace facebook_csharp_ads_sdk.Domain.Contracts.Repository
+{
+    public interface IAdStatisticsRepository : IBaseRepository<BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>>
+    {
+        Task<BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>> Read(long id, DateTime? startTimeUtc, DateTime? endTimeUtc);
+    }
+}

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Extensions/AdStatistics/AdStatisticsExtensions.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Extensions/AdStatistics/AdStatisticsExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using facebook_csharp_ads_sdk.Domain.Contracts.AdStatistics;
+using facebook_csharp_ads_sdk.Domain.Models.AdStatistics;
+
+namespace facebook_csharp_ads_sdk.Domain.Extensions.AdStatistics
+{
+    /// <summary>
+    /// Extension methods for Facebook ad statistics
+    /// </summary>
+    public static class AdStatisticsExtensions
+    {
+        /// <summary>
+        /// Query statistics of a Facebook ad object. When no date is provided, lifetime stats are returned. 
+        /// With only start time provided, stats are returned since that date, and when both start and end time 
+        /// are provided, stats are returned for the date interval.
+        /// </summary>
+        /// <param name="startTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
+        /// <param name="endTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
+        /// <returns></returns>
+        public static IList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics> stats(this IAdStatisticsQueryable adObject, DateTime startTimeUtc, DateTime endTimeUtc)
+        {
+            return new List<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>();
+        }
+    }
+}

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Extensions/AdStatistics/AdStatisticsExtensions.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Extensions/AdStatistics/AdStatisticsExtensions.cs
@@ -24,10 +24,9 @@ namespace facebook_csharp_ads_sdk.Domain.Extensions.AdStatistics
         /// <param name="startTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
         /// <param name="endTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
         /// <returns>list of base objects of type AdStatistics</returns>
-        public static async Task<BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>> stats(this IAdStatisticsQueryable adObject, long adObjectId, DateTime? startTimeUtc, DateTime? endTimeUtc)
+        public static async Task<BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>> GetStatistics(this IAdStatisticsQueryable adObject, long adObjectId, DateTime? startTimeUtc, DateTime? endTimeUtc)
         {
-            var _repository = new AdStatisticsRepository(new FacebookSessionRepository());
-            return await _repository.Read(adObjectId, startTimeUtc, endTimeUtc);
+            return await adObject._adStatisticsRepository.Read(adObjectId, startTimeUtc, endTimeUtc);
         }
     }
 }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Extensions/AdStatistics/AdStatisticsExtensions.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Extensions/AdStatistics/AdStatisticsExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using System.Threading.Tasks;
 using facebook_csharp_ads_sdk.Domain.Contracts.AdStatistics;
 using facebook_csharp_ads_sdk.Domain.Models.AdStatistics;
+using facebook_csharp_ads_sdk.Domain.Models;
+using facebook_csharp_ads_sdk.Infrastructure.Repository;
 
 namespace facebook_csharp_ads_sdk.Domain.Extensions.AdStatistics
 {
@@ -18,12 +20,14 @@ namespace facebook_csharp_ads_sdk.Domain.Extensions.AdStatistics
         /// With only start time provided, stats are returned since that date, and when both start and end time 
         /// are provided, stats are returned for the date interval.
         /// </summary>
+        /// <param name="adObjectId"> Id of Ad, Ad Set, Ad Campaign or Ad Account</param>
         /// <param name="startTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
         /// <param name="endTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
-        /// <returns></returns>
-        public static IList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics> stats(this IAdStatisticsQueryable adObject, DateTime startTimeUtc, DateTime endTimeUtc)
+        /// <returns>list of base objects of type AdStatistics</returns>
+        public static async Task<BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>> stats(this IAdStatisticsQueryable adObject, long adObjectId, DateTime? startTimeUtc, DateTime? endTimeUtc)
         {
-            return new List<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>();
+            var _repository = new AdStatisticsRepository(new FacebookSessionRepository());
+            return await _repository.Read(adObjectId, startTimeUtc, endTimeUtc);
         }
     }
 }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdAccounts/AdAccount.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdAccounts/AdAccount.cs
@@ -13,6 +13,8 @@ using facebook_csharp_ads_sdk.Domain.Models.ApiErrors;
 using facebook_csharp_ads_sdk.Domain.Models.Attributes;
 using Newtonsoft.Json.Linq;
 using facebook_csharp_ads_sdk.Domain.Contracts.AdStatistics;
+using facebook_csharp_ads_sdk.Domain.Extensions.AdStatistics;
+using System.Threading.Tasks;
 
 namespace facebook_csharp_ads_sdk.Domain.Models.AdAccounts
 {
@@ -28,6 +30,11 @@ namespace facebook_csharp_ads_sdk.Domain.Models.AdAccounts
         /// </summary>
         private readonly IAccountRepository _repository;
 
+        /// <summary>
+        ///     Repository of the ad statistics interface
+        /// </summary>
+        public IAdStatisticsRepository _adStatisticsRepository { get; private set; }
+
         #endregion Dependencies
 
         #region Constructor
@@ -36,9 +43,11 @@ namespace facebook_csharp_ads_sdk.Domain.Models.AdAccounts
         ///     Constructor
         /// </summary>
         /// <param name="repository"> Implementation of the account interface repository </param>
-        public AdAccount(IAccountRepository repository)
+        /// <param name="adStatisticsRepository"> Implementation of the ad statistics interface repository </param>
+        public AdAccount(IAccountRepository repository, IAdStatisticsRepository adStatisticsRepository)
         {
             this._repository = repository;
+            this._adStatisticsRepository = adStatisticsRepository;
         }
 
         #endregion Constructor
@@ -516,6 +525,21 @@ namespace facebook_csharp_ads_sdk.Domain.Models.AdAccounts
         {
             throw new NotImplementedException();
         }
+
+        #region Ad Statistics
+        /// <summary>
+        /// Query statistics of a Facebook ad object. When no date is provided, lifetime stats are returned. 
+        /// With only start time provided, stats are returned since that date, and when both start and end time 
+        /// are provided, stats are returned for the date interval.
+        /// </summary>
+        /// <param name="startTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
+        /// <param name="endTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
+        /// <returns>list of base objects of type AdStatistics</returns>
+        public async Task<BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>> GetStatistics(DateTime? startDateUtc, DateTime? endDateUtc) 
+        {
+            return await this.GetStatistics(AccountId, startDateUtc, endDateUtc);
+        }
+        #endregion
 
         ///// <summary>
         /////     Parse Facebook response to Model

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdAccounts/AdAccount.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdAccounts/AdAccount.cs
@@ -12,13 +12,14 @@ using facebook_csharp_ads_sdk.Domain.Models.AdAccountsGroup;
 using facebook_csharp_ads_sdk.Domain.Models.ApiErrors;
 using facebook_csharp_ads_sdk.Domain.Models.Attributes;
 using Newtonsoft.Json.Linq;
+using facebook_csharp_ads_sdk.Domain.Contracts.AdStatistics;
 
 namespace facebook_csharp_ads_sdk.Domain.Models.AdAccounts
 {
     /// <summary>
     /// https://developers.facebook.com/docs/reference/ads-api/adaccount#read
     /// </summary>
-    public class AdAccount : BaseCrudObject<AdAccount>
+    public class AdAccount : BaseCrudObject<AdAccount>, IAdStatisticsQueryable
     {
         #region Dependencies
 

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdAccounts/AdAccount.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdAccounts/AdAccount.cs
@@ -389,7 +389,7 @@ namespace facebook_csharp_ads_sdk.Domain.Models.AdAccounts
                         continue;
 
                     var groupData = new AdAccountGroup();
-                    groupData.ParseReadSingleesponse(currentGroup);
+                    groupData.ParseReadSingleResponse(currentGroup);
 
                     if (!groupData.IsValid)
                         continue;

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdAccountsGroup/AdAccountGroup.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdAccountsGroup/AdAccountGroup.cs
@@ -114,7 +114,7 @@ namespace facebook_csharp_ads_sdk.Domain.Models.AdAccountsGroup
             } 
             #endregion
 
-            this.ParseReadSingleesponse(jsonObject);
+            this.ParseReadSingleResponse(jsonObject);
             return this;
         }
 
@@ -152,7 +152,7 @@ namespace facebook_csharp_ads_sdk.Domain.Models.AdAccountsGroup
                     continue;
 
                 var accountGroup = new AdAccountGroup();
-                accountGroup.ParseReadSingleesponse(item.ToString());
+                accountGroup.ParseReadSingleResponse(item.ToString());
                 if (!accountGroup.IsValid)
                     continue;
 

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdCampaigns/AdCampaign.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdCampaigns/AdCampaign.cs
@@ -219,9 +219,9 @@ namespace facebook_csharp_ads_sdk.Domain.Models.AdCampaigns
         ///     Overrite of the base parse method 
         /// </summary>
         /// <param name="facebookResponse"> Facebook response </param>
-        public override void ParseReadSingleesponse(string facebookResponse)
+        public override void ParseReadSingleResponse(string facebookResponse)
         {
-            base.ParseReadSingleesponse(facebookResponse);
+            base.ParseReadSingleResponse(facebookResponse);
             if (!this.IsValid)
             {
                 return;

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdCampaigns/AdCampaign.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdCampaigns/AdCampaign.cs
@@ -13,10 +13,13 @@ using facebook_csharp_ads_sdk.Domain.Extensions.Enums.AdCampaigns;
 using facebook_csharp_ads_sdk.Domain.Extensions.Enums.Global;
 using facebook_csharp_ads_sdk.Domain.Models.Attributes;
 using Newtonsoft.Json.Linq;
+using facebook_csharp_ads_sdk.Domain.Contracts.AdStatistics;
+using facebook_csharp_ads_sdk.Domain.Extensions.AdStatistics;
+using System.Threading.Tasks;
 
 namespace facebook_csharp_ads_sdk.Domain.Models.AdCampaigns
 {
-    public class AdCampaign : BaseCrudObject<AdCampaign>
+    public class AdCampaign : BaseCrudObject<AdCampaign>, IAdStatisticsQueryable
     {
         #region Dependencies
 
@@ -24,6 +27,11 @@ namespace facebook_csharp_ads_sdk.Domain.Models.AdCampaigns
         ///     Interface of the campaign repository
         /// </summary>
         private readonly ICampaignRepository campaignRepository;
+
+        /// <summary>
+        ///     Repository of the ad statistics interface
+        /// </summary>
+        public IAdStatisticsRepository _adStatisticsRepository { get; private set; }
 
         #endregion Dependencies
 
@@ -33,9 +41,11 @@ namespace facebook_csharp_ads_sdk.Domain.Models.AdCampaigns
         ///     Constructor
         /// </summary>
         /// <param name="campaignRepository"> Interface of the campaign repository </param>
-        public AdCampaign(ICampaignRepository campaignRepository)
+        /// <param name="adStatisticsRepository"> Interface of the ad statistics repository </param>
+        public AdCampaign(ICampaignRepository campaignRepository, IAdStatisticsRepository adStatisticsRepository)
         {
             this.campaignRepository = campaignRepository;
+            this._adStatisticsRepository = adStatisticsRepository;
         }
 
         #endregion Constructor
@@ -466,6 +476,21 @@ namespace facebook_csharp_ads_sdk.Domain.Models.AdCampaigns
 
             return createQuery;
         }
+
+        #region Ad Statistics
+        /// <summary>
+        /// Query statistics of a Facebook ad object. When no date is provided, lifetime stats are returned. 
+        /// With only start time provided, stats are returned since that date, and when both start and end time 
+        /// are provided, stats are returned for the date interval.
+        /// </summary>
+        /// <param name="startTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
+        /// <param name="endTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
+        /// <returns>list of base objects of type AdStatistics</returns>
+        public async Task<BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>> GetStatistics(DateTime? startDateUtc, DateTime? endDateUtc)
+        {
+            return await this.GetStatistics(Id, startDateUtc, endDateUtc);
+        }
+        #endregion
 
         #region Private methods
 

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdStatistics/AdStatistics.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdStatistics/AdStatistics.cs
@@ -134,47 +134,9 @@ namespace facebook_csharp_ads_sdk.Domain.Models.AdStatistics
         /// <summary>
         /// Método para parse multiplo dos dados de uma lista de grupo de contas
         /// </summary>
-        public BaseObjectsList<AdStatistics> ParseMultipleResponse(string response)
+        public static BaseObjectsList<AdStatistics> ParseMultipleResponse(string response)
         {
-            var objectResult = new BaseObjectsList<AdStatistics>();
-
-            if (String.IsNullOrEmpty(response))
-                return objectResult;
-
-            var jsonObject = JObject.Parse(response);
-            if (jsonObject == null)
-                return objectResult;
-
-            #region Error
-            if (jsonObject["error"] != null)
-            {
-                var errorModel = new ApiErrorModelV22().ParseApiResponse(jsonObject);
-                objectResult.SetInvalid();
-                objectResult.SetApiErrorResonse(errorModel);
-
-                return objectResult;
-            }
-            #endregion
-
-            if (jsonObject["data"] == null)
-                return objectResult;
-
-            foreach (var item in jsonObject["data"])
-            {
-                if (item.Type != JTokenType.Object)
-                    continue;
-
-                var adStats = new AdStatistics();
-                adStats.ParseReadSingleResponse(item.ToString());
-                if (!adStats.IsValid)
-                    continue;
-
-                objectResult.Add(adStats);
-            }
-
-            objectResult.SetValid();
-
-            return objectResult;
+            return new BaseObjectsList<AdStatistics>().ParseReadMultipleResponse(response);
         }
         #endregion
     }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdStatistics/AdStatistics.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/AdStatistics/AdStatistics.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+using facebook_csharp_ads_sdk.Domain.Models.Attributes;
+using facebook_csharp_ads_sdk.Domain.Models.ApiErrors;
+using Newtonsoft.Json.Linq;
+
+namespace facebook_csharp_ads_sdk.Domain.Models.AdStatistics
+{
+    /// <summary>
+    /// Statistics for Facebook ad account, group, campaign or set
+    /// </summary>
+    public class AdStatistics : BaseObject
+    {
+        #region properties
+        /// <summary>
+        /// Statistics object id
+        /// </summary>
+        [DefaultValue(null)]
+        [FacebookName("id")]
+        public long Id { get; private set; }
+
+        /// <summary>
+        /// Number of ads served
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("impressions")]
+        public long Impressions { get; private set; }
+
+        /// <summary>
+        /// Number of clicks received
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("clicks")]
+        public long Clciks { get; private set; }
+
+        /// <summary>
+        /// Amount spent in the ad account currency. Need to apply currency offset
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("spent")]
+        public long Spent { get; private set; }
+
+        /// <summary>
+        /// Ads that were served with social context
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("social_impressions")]
+        public long SocialImpressions { get; private set; }
+
+        /// <summary>
+        /// Clicks on ads that were shown with social context
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("social_clicks")]
+        public long SocialClicks { get; private set; }
+
+        /// <summary>
+        /// The amount spent on ads with social context
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("social_spent")]
+        public long SocialSpent { get; private set; }
+
+        /// <summary>
+        /// The number of individuals this ad was served to on the site
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("unique_impressions")]
+        public long UniqueImpressions { get; private set; }
+
+        /// <summary>
+        /// The number of individuals this ad was served to with social context
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("social_unique_impressions")]
+        public long SocialUniqueImpressions { get; private set; }
+
+        /// <summary>
+        /// The number of individuals who clicked this ad.
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("unique_clicks")]
+        public long UniqueClicks { get; private set; }
+
+        /// <summary>
+        /// The number of individuals who clicked this ad while it had social context
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("unique_clicks")]
+        public long SocialUniqueClicks { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("actions")]
+        public JObject Actions { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("inline_actions")]
+        public JObject InlineActions { get; private set; }
+
+        /// <summary>
+        /// The ID of the object the statistics refer to, this may also be adcampaign_id or adgroup_id
+        /// </summary>
+        [DefaultValue(0L)]
+        [FacebookName("account_id")]
+        public long AccountId { get; private set; }
+
+        /// <summary>
+        /// A timestamp of the start of the statistics period
+        /// </summary>
+        [DefaultValue(null)]
+        [FacebookName("start_time")]
+        public DateTime StartTime { get; private set; }
+
+        /// <summary>
+        /// A timestamp of the end of the statistics period
+        /// </summary>
+        [DefaultValue(null)]
+        [FacebookName("end_time")]
+        public DateTime EndTime { get; private set; }
+        #endregion
+
+        #region Métodos para parse das respostas do Facebook
+
+        /// <summary>
+        /// Método para parse multiplo dos dados de uma lista de grupo de contas
+        /// </summary>
+        public BaseObjectsList<AdStatistics> ParseMultipleResponse(string response)
+        {
+            var objectResult = new BaseObjectsList<AdStatistics>();
+
+            if (String.IsNullOrEmpty(response))
+                return objectResult;
+
+            var jsonObject = JObject.Parse(response);
+            if (jsonObject == null)
+                return objectResult;
+
+            #region Error
+            if (jsonObject["error"] != null)
+            {
+                var errorModel = new ApiErrorModelV22().ParseApiResponse(jsonObject);
+                objectResult.SetInvalid();
+                objectResult.SetApiErrorResonse(errorModel);
+
+                return objectResult;
+            }
+            #endregion
+
+            if (jsonObject["data"] == null)
+                return objectResult;
+
+            foreach (var item in jsonObject["data"])
+            {
+                if (item.Type != JTokenType.Object)
+                    continue;
+
+                var adStats = new AdStatistics();
+                adStats.ParseReadSingleResponse(item.ToString());
+                if (!adStats.IsValid)
+                    continue;
+
+                objectResult.Add(adStats);
+            }
+
+            objectResult.SetValid();
+
+            return objectResult;
+        }
+        #endregion
+    }
+}

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/BaseObject.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/BaseObject.cs
@@ -56,7 +56,7 @@ namespace facebook_csharp_ads_sdk.Domain.Models
         /// <summary>
         /// Parse Facebook Api response to model
         /// </summary>
-        public virtual void ParseReadSingleesponse(string facebookResponse)
+        public virtual void ParseReadSingleResponse(string facebookResponse)
         {
             try
             {
@@ -66,7 +66,7 @@ namespace facebook_csharp_ads_sdk.Domain.Models
                 }
 
                 var response = JObject.Parse(facebookResponse);
-                this.ParseReadSingleesponse(response);
+                this.ParseReadSingleResponse(response);
             }
             catch (Exception)
             {
@@ -77,7 +77,7 @@ namespace facebook_csharp_ads_sdk.Domain.Models
         /// <summary>
         /// Parse Facebook Api response to model
         /// </summary>
-        public virtual void ParseReadSingleesponse(JToken facebookResponse)
+        public virtual void ParseReadSingleResponse(JToken facebookResponse)
         {
             try
             {

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/BaseObjectsList.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/BaseObjectsList.cs
@@ -1,12 +1,15 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using facebook_csharp_ads_sdk.Domain.Models.ApiErrors;
+using facebook_csharp_ads_sdk._Utils.Parser;
+using Newtonsoft.Json.Linq;
 
 namespace facebook_csharp_ads_sdk.Domain.Models
 {
     /// <summary>
     ///     Base object to models 
     /// </summary>
-    public class BaseObjectsList<T>
+    public class BaseObjectsList<T> where T : BaseObject, new()
     {
         #region Properties
         /// <summary>
@@ -91,5 +94,79 @@ namespace facebook_csharp_ads_sdk.Domain.Models
             ApiErrorResponseData = errorResponse;
         } 
         #endregion
+
+        #region parse facebook response methods
+        /// <summary>
+        /// Parse Facebook Api response to model
+        /// </summary>
+        public virtual BaseObjectsList<T> ParseReadMultipleResponse(string facebookResponse)
+        {
+            try
+            {
+                if (String.IsNullOrEmpty(facebookResponse))
+                    this.SetInvalid();
+
+                var response = JObject.Parse(facebookResponse);
+                return this.ParseReadMultipleResponse(response);
+            }
+            catch (Exception)
+            {
+                this.SetInvalid();
+                return this;
+            }
+        }
+
+        /// <summary>
+        /// Parse Facebook Api response to model
+        /// </summary>
+        public virtual BaseObjectsList<T> ParseReadMultipleResponse(JToken facebookResponse)
+        {
+            try
+            {
+                if (facebookResponse == null)
+                {
+                    this.SetInvalid();
+                    return this;
+                }
+
+                #region Error
+                if (facebookResponse["error"] != null)
+                {
+                    var errorModel = new ApiErrorModelV22().ParseApiResponse(facebookResponse);
+                    this.SetInvalid();
+                    this.SetApiErrorResonse(errorModel);
+
+                    return this;
+                }
+                #endregion
+
+                if (facebookResponse["data"] == null)
+                    return this;
+
+                foreach (var item in facebookResponse["data"])
+                {
+                    if (item.Type != JTokenType.Object)
+                        continue;
+
+                    var responseItem = new T();
+                    responseItem.ParseReadSingleResponse(item.ToString());
+                    if (!responseItem.IsValid)
+                        continue;
+
+                    this.Add(responseItem);
+                }
+
+                this.SetValid();
+
+                return this;
+            }
+            catch (Exception)
+            {
+                this.SetInvalid();
+                return this;
+            }
+        }
+        #endregion
+
     }
 }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/Configurations/FacebookAdsApiConfiguration.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Domain/Models/Configurations/FacebookAdsApiConfiguration.cs
@@ -93,6 +93,13 @@ namespace facebook_csharp_ads_sdk.Domain.Models.Configurations
 
         #endregion Ad campaign
 
+        #region Ad Statistics
+        /// <summary>
+        /// Uri to read as statistics data
+        /// </summary>
+        public string AdStatisticsEndpoint { get; private set; }
+        #endregion
+
         /// <summary>
         /// Base constructor
         /// </summary>
@@ -101,6 +108,7 @@ namespace facebook_csharp_ads_sdk.Domain.Models.Configurations
             SetGlobalConfigurations();
             SetAdAccountConfigurations();
             SetAdAccountGroupConfigurations();
+            SetAdStatisticsConfigurations();
         }
 
         private void SetGlobalConfigurations()
@@ -120,6 +128,10 @@ namespace facebook_csharp_ads_sdk.Domain.Models.Configurations
             AdAccountGroupFields = AdAccountGroupFieldsEnumExtensions.GetAllAdAccountGroupFieldsList();
             AdAccountGroupSingleEndpoint = GraphApiUrl + "{0}?access_token={1}&fields={2}";
             AdAccountGroupAllEndpoint = GraphApiUrl + "me/adaccountgroups?access_token={0}&fields={1}";
+        }
+
+        private void SetAdStatisticsConfigurations() {
+            AdStatisticsEndpoint = GraphApiUrl + "stats?access_token={0}&ids={1}&start_time={2}&end_time={3}";
         }
     }
 }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/AdAccountGroupRespository.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/AdAccountGroupRespository.cs
@@ -59,7 +59,7 @@ namespace facebook_csharp_ads_sdk.Infrastructure.Repository
             IRequest webRequest = new Request();
             var getRequest = webRequest.Get(accountEndpoint);
             var accountGroup = new AdAccountGroup();
-            accountGroup.ParseReadSingleesponse(getRequest);
+            accountGroup.ParseReadSingleResponse(getRequest);
             return accountGroup;
         }
 

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/AdAccountRespository.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/AdAccountRespository.cs
@@ -71,7 +71,7 @@ namespace facebook_csharp_ads_sdk.Infrastructure.Repository
 
             IRequest webRequest = new Request();
             var getRequest = await webRequest.GetAsync(accountEndpoint);
-            var account = new AdAccount(this);
+            var account = new AdAccount(this, new AdStatisticsRepository(this._facebookSession));
             account.ParseReadSingleResponse(getRequest);
             return account;
         }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/AdAccountRespository.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/AdAccountRespository.cs
@@ -14,7 +14,7 @@ namespace facebook_csharp_ads_sdk.Infrastructure.Repository
     /// <summary>
     /// Implement Facebook AdAccount interface methods
     /// </summary>
-    public class AdAccountRespository : IAccountRepository
+    public class AdAccountRepository : IAccountRepository
     {
         #region Properties
         
@@ -31,7 +31,7 @@ namespace facebook_csharp_ads_sdk.Infrastructure.Repository
         /// Repository constructor with an instance of Facebook Session
         /// </summary>
         /// <exception cref="ArgumentNullException"></exception>
-        public AdAccountRespository(IFacebookSession facebookSession)
+        public AdAccountRepository(IFacebookSession facebookSession)
         {
             if (facebookSession == null)
                 throw new ArgumentNullException();

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/AdAccountRespository.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/AdAccountRespository.cs
@@ -72,7 +72,7 @@ namespace facebook_csharp_ads_sdk.Infrastructure.Repository
             IRequest webRequest = new Request();
             var getRequest = await webRequest.GetAsync(accountEndpoint);
             var account = new AdAccount(this);
-            account.ParseReadSingleesponse(getRequest);
+            account.ParseReadSingleResponse(getRequest);
             return account;
         }
     }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/AdStatisticsRepository.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/AdStatisticsRepository.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using facebook_csharp_ads_sdk.Domain.Contracts.Repository;
+using facebook_csharp_ads_sdk.Domain.Models;
+using facebook_csharp_ads_sdk.Domain.Models.AdStatistics;
+using facebook_csharp_ads_sdk.Domain.Enums.FacebookSession;
+using facebook_csharp_ads_sdk._Utils.WebRequests;
+
+namespace facebook_csharp_ads_sdk.Infrastructure.Repository
+{
+    /// <summary>
+    /// Ad Statistics repository
+    /// </summary>
+    public class AdStatisticsRepository : IAdStatisticsRepository
+    {
+        #region Properties
+        
+        /// <summary>
+        ///     Instance of the facebook session
+        /// </summary>
+        private readonly IFacebookSession _facebookSession;
+
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        /// Repository constructor with an instance of Facebook Session
+        /// </summary>
+        /// <exception cref="ArgumentNullException"></exception>
+        public AdStatisticsRepository(IFacebookSession facebookSession)
+        {
+            if (facebookSession == null)
+                throw new ArgumentNullException();
+
+            this._facebookSession = facebookSession;
+        } 
+
+        #endregion
+
+        /// <summary>
+        /// Query statistics of a Facebook ad object. When no date is provided, lifetime stats are returned. 
+        /// With only start time provided, stats are returned since that date, and when both start and end time 
+        /// are provided, stats are returned for the date interval.
+        /// </summary>
+        /// <param name="adObjectId"> Id of Ad, Ad Set, Ad Campaign or Ad Account</param>
+        /// <param name="startTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
+        /// <param name="endTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
+        /// <returns>list of base objects of type AdStatistics</returns>
+        /// <exception cref="ArgumentException">When dates are not in utc, ArgumentException is thrown</exception>
+        public async Task<BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>> Read(long id)
+        {
+            return await this.Read(id, null, null);
+        }
+
+        /// <summary>
+        /// Query statistics of a Facebook ad object. When no date is provided, lifetime stats are returned. 
+        /// With only start time provided, stats are returned since that date, and when both start and end time 
+        /// are provided, stats are returned for the date interval.
+        /// </summary>
+        /// <param name="adObjectId"> Id of Ad, Ad Set, Ad Campaign or Ad Account</param>
+        /// <param name="startTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
+        /// <param name="endTimeUtc">(optional) start time of statistics in UTC in the ad account timezone</param>
+        /// <returns>list of base objects of type AdStatistics</returns>
+        /// <exception cref="ArgumentException">When dates are not in utc, ArgumentException is thrown</exception>
+        public async Task<BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>> Read(long id, DateTime? startTimeUtc, DateTime? endTimeUtc)
+        {
+            if (startTimeUtc.HasValue && startTimeUtc.Value.Kind != DateTimeKind.Utc)
+                throw new ArgumentException("Argument must be of DateTimeKind Utc", "startTimeUtc");
+            else if (endTimeUtc.HasValue && endTimeUtc.Value.Kind != DateTimeKind.Utc)
+                throw new ArgumentException("Argument must be of DateTimeKind Utc", "endTimeUtc");
+
+            this._facebookSession.ValidateFacebookSessionRequirements(new[] { RequiredOnFacebookSessionEnum.UserAccessToken });
+
+            string statsEndpoint = this._facebookSession.GetFacebookAdsApiConfiguration().AdStatisticsEndpoint;
+            statsEndpoint = string.Format(statsEndpoint, this._facebookSession.GetUserAccessToken(), id, 
+                startTimeUtc.HasValue ? startTimeUtc.ToString() : string.Empty,
+                endTimeUtc.HasValue ? endTimeUtc.ToString() : string.Empty);
+            
+            IRequest webRequest = new Request();
+            var getRequest = await webRequest.GetAsync(statsEndpoint);
+
+            return new BaseObjectsList<facebook_csharp_ads_sdk.Domain.Models.AdStatistics.AdStatistics>().ParseReadMultipleResponse(getRequest);
+        }
+    }
+}

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/CampaignRepository.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/CampaignRepository.cs
@@ -102,7 +102,7 @@ namespace facebook_csharp_ads_sdk.Infrastructure.Repository
 
             IRequest webRequest = new Request();
             string getRequest = await webRequest.GetAsync(campaignEndpoint);
-            var account = new AdCampaign(this);
+            var account = new AdCampaign(this, new AdStatisticsRepository(this.facebookSession));
             account.ParseReadSingleResponse(getRequest);
             return account;
         }
@@ -120,7 +120,7 @@ namespace facebook_csharp_ads_sdk.Infrastructure.Repository
 
             IRequest webRequest = new Request();
             string deleteRequest = await webRequest.DeleteAsync(deleteEndpoint);
-            var account = new AdCampaign(this);
+            var account = new AdCampaign(this, new AdStatisticsRepository(this.facebookSession));
             
             return account.ParseDeleteResponse(deleteRequest);
         }

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/CampaignRepository.cs
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/Infrastructure/Repository/CampaignRepository.cs
@@ -103,7 +103,7 @@ namespace facebook_csharp_ads_sdk.Infrastructure.Repository
             IRequest webRequest = new Request();
             string getRequest = await webRequest.GetAsync(campaignEndpoint);
             var account = new AdCampaign(this);
-            account.ParseReadSingleesponse(getRequest);
+            account.ParseReadSingleResponse(getRequest);
             return account;
         }
         

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk.csproj
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Domain\BusinessRules\App\BasicData.cs" />
     <Compile Include="Domain\BusinessRules\Users\UserAccessToken.cs" />
     <Compile Include="Domain\Contracts\AdStatistics\IAdStatisticsQueryable.cs" />
+    <Compile Include="Domain\Contracts\Repository\IAdStatisticsRepository.cs" />
     <Compile Include="Domain\Contracts\Repository\IBaseCrudRepository.cs" />
     <Compile Include="Domain\Contracts\Repository\ICampaignRepository.cs" />
     <Compile Include="Domain\Contracts\Repository\IAccountGroupRepository.cs" />
@@ -129,6 +130,7 @@
     <Compile Include="Infrastructure\Repository\AdAccountGroupRespository.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Infrastructure\Repository\AdStatisticsRepository.cs" />
     <Compile Include="_Utils\Parser\FacebookParser.cs" />
     <Compile Include="Infrastructure\Repository\AdAccountRespository.cs" />
     <Compile Include="Infrastructure\Repository\CampaignRepository.cs" />

--- a/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk.csproj
+++ b/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk/facebook-csharp-ads-sdk.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Domain\BusinessRules\AdAccounts\BasicData.cs" />
     <Compile Include="Domain\BusinessRules\App\BasicData.cs" />
     <Compile Include="Domain\BusinessRules\Users\UserAccessToken.cs" />
+    <Compile Include="Domain\Contracts\AdStatistics\IAdStatisticsQueryable.cs" />
     <Compile Include="Domain\Contracts\Repository\IBaseCrudRepository.cs" />
     <Compile Include="Domain\Contracts\Repository\ICampaignRepository.cs" />
     <Compile Include="Domain\Contracts\Repository\IAccountGroupRepository.cs" />
@@ -72,6 +73,7 @@
     <Compile Include="Domain\Enums\Global\ExecutionOptionsEnum.cs" />
     <Compile Include="Domain\Exceptions\AdAccounts\InvalidAdAccountId.cs" />
     <Compile Include="Domain\Exceptions\Users\InvalidUserAccessToken.cs" />
+    <Compile Include="Domain\Extensions\AdStatistics\AdStatisticsExtensions.cs" />
     <Compile Include="Domain\Extensions\Enums\AdAccountGroup\AdAccountGroupFieldsEnumExtensions.cs" />
     <Compile Include="Domain\Extensions\Enums\AdAccountGroup\AdAccountGroupsStatusEnumExtensions.cs" />
     <Compile Include="Domain\Extensions\Enums\AdAccounts\AdAccountStatusEnumExtensions.cs" />
@@ -109,6 +111,7 @@
     <Compile Include="Domain\Models\AdAccountsGroup\AdAccountGroup.cs" />
     <Compile Include="Domain\Models\AdAccounts\TimezoneInformations.cs" />
     <Compile Include="Domain\Models\AdCampaigns\AdCampaign.cs" />
+    <Compile Include="Domain\Models\AdStatistics\AdStatistics.cs" />
     <Compile Include="Domain\Models\ApiErrors\ApiErrorModelV22.cs" />
     <Compile Include="Domain\Models\Attributes\CanCreateOnFacebookAttribute.cs" />
     <Compile Include="Domain\Models\Attributes\CanUpdateOnFacebookAttribute.cs" />


### PR DESCRIPTION
Implementacao de Ad Statistics. Ad account, campaign, set e ad devem implementar a interface IAdStatisticsQueryable para poder ler as estatisticas do facebook.

https://developers.facebook.com/docs/reference/ads-api/adstatistics/v2.2?locale=pt_BR